### PR TITLE
Restore Native Window Shadows

### DIFF
--- a/Resources/Base.lproj/MainMenu.xib
+++ b/Resources/Base.lproj/MainMenu.xib
@@ -300,7 +300,7 @@
             </items>
             <point key="canvasLocation" x="162" y="496"/>
         </menu>
-        <window title="Hermes" separatorStyle="line" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" hasShadow="NO" releasedWhenClosed="NO" appearanceType="aqua" frameAutosaveName="Preferences" animationBehavior="default" tabbingMode="disallowed" toolbarStyle="expanded" id="371" userLabel="Main Window" customClass="HermesMainWindow">
+        <window title="Hermes" separatorStyle="line" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" hasShadow="YES" releasedWhenClosed="NO" appearanceType="aqua" frameAutosaveName="Preferences" animationBehavior="default" tabbingMode="disallowed" toolbarStyle="expanded" id="371" userLabel="Main Window" customClass="HermesMainWindow">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <rect key="contentRect" x="300" y="434" width="240" height="294"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1440" height="900"/>
@@ -859,7 +859,7 @@ Gw
             <point key="canvasLocation" x="244" y="255.5"/>
         </window>
         <userDefaultsController representsSharedInstance="YES" id="979"/>
-        <window title="Preferences" separatorStyle="line" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" hasShadow="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" appearanceType="aqua" frameAutosaveName="Hermes Preferences" animationBehavior="default" toolbarStyle="expanded" id="1112" userLabel="Preferences Window">
+        <window title="Preferences" separatorStyle="line" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" hasShadow="YES" releasedWhenClosed="NO" visibleAtLaunch="NO" appearanceType="aqua" frameAutosaveName="Hermes Preferences" animationBehavior="default" toolbarStyle="expanded" id="1112" userLabel="Preferences Window">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES"/>
             <rect key="contentRect" x="0.0" y="0.0" width="362" height="451"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1440" height="900"/>

--- a/Sources/Controllers/PreferencesController.m
+++ b/Sources/Controllers/PreferencesController.m
@@ -9,6 +9,9 @@
 - (void)awakeFromNib {
   [super awakeFromNib];
 
+  [window setHasShadow:YES];
+  [window invalidateShadow];
+
   [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(proxyServerValidityChanged:) name:URLConnectionProxyValidityChangedNotification object:nil];
 }
 

--- a/Sources/HermesAppDelegate.m
+++ b/Sources/HermesAppDelegate.m
@@ -198,6 +198,8 @@
   
   window.restorable = YES;
   window.restorationClass = [self class];
+  [window setHasShadow:YES];
+  [window invalidateShadow];
 
   [NSApp activateIgnoringOtherApps:YES];
 


### PR DESCRIPTION
Add a box shadow to main & settings windows to give a more MacOS native look & feel to the app.

### Before

<img width="1100" height="801" alt="flat" src="https://github.com/user-attachments/assets/92109f7a-faa0-4dd6-adaf-d38cc8bf1479" />

### After

<img width="1167" height="811" alt="box-shadow" src="https://github.com/user-attachments/assets/00b0ba8d-c0b7-4a86-8248-1121d283ee1e" />
