### PR TITLE
Add Homebrew tap installation

### DIFF
--- a/Casks/apollogene.rb
+++ b/Casks/apollogene.rb
@@ -1,0 +1,18 @@
+cask "apollogene" do
+  version "200b6"
+  sha256 "2bf92aab9473246bed2d5cad52d19d6d13643c13ca06168bf32b5cf4f37e1702"
+
+  url "https://github.com/dtseto/Hermes-master/releases/download/v#{version}/ApolloGene#{version}-n.zip"
+  name "ApolloGene"
+  desc "Pandora client for Intel and Apple Silicon Macs"
+  homepage "https://github.com/dtseto/Hermes-master"
+
+  depends_on macos: :big_sur
+
+  app "ApolloGene#{version}-n.app", target: "ApolloGene.app"
+
+  zap trash: [
+    "~/Library/Preferences/com.davidseto.ApolloGene.plist",
+    "~/Library/Saved Application State/com.davidseto.ApolloGene.savedState",
+  ]
+end

--- a/Casks/apollogene.rb
+++ b/Casks/apollogene.rb
@@ -1,18 +1,20 @@
 cask "apollogene" do
-  version "200b6"
-  sha256 "2bf92aab9473246bed2d5cad52d19d6d13643c13ca06168bf32b5cf4f37e1702"
+  version "201b1"
+  sha256 "233218cb60088a6011d6558a94bed335dcdeba85df769696c23c51d288817c2d"
 
-  url "https://github.com/dtseto/Hermes-master/releases/download/v#{version}/ApolloGene#{version}-n.zip"
+  url "https://github.com/dtseto/Hermes-master/releases/download/v#{version}/ApolloGene-n.app.zip"
   name "ApolloGene"
   desc "Pandora client for Intel and Apple Silicon Macs"
   homepage "https://github.com/dtseto/Hermes-master"
 
   depends_on macos: :big_sur
 
-  app "ApolloGene#{version}-n.app", target: "ApolloGene.app"
+  app "ApolloGene-n.app", target: "ApolloGene.app"
 
   zap trash: [
     "~/Library/Preferences/com.davidseto.ApolloGene.plist",
+    "~/Library/Preferences/com.dtseto.ApolloGene.plist",
     "~/Library/Saved Application State/com.davidseto.ApolloGene.savedState",
+    "~/Library/Saved Application State/com.dtseto.ApolloGene.savedState",
   ]
 end

--- a/README.md
+++ b/README.md
@@ -50,6 +50,21 @@ You can also make pull requests and add to issues and I will try to reply.
 
 - On newer MAC OS download the app, extract if needed, double click to open, on warning message, open again, go to system settings, privacy and security, scroll to the bottom and click open anyways, open the app enter your password should open normally after.
 
+### Install with Homebrew
+
+This repository can be added directly as a Homebrew tap. Install the latest
+universal release (Intel and Apple Silicon) with:
+
+```sh
+brew tap dtseto/hermes-master https://github.com/dtseto/Hermes-master.git
+brew trust dtseto/hermes-master
+brew install --cask apollogene
+```
+
+Homebrew installs the application as `ApolloGene.app`. To upgrade or uninstall
+it later, run `brew upgrade --cask apollogene` or
+`brew uninstall --cask apollogene`.
+
 If you would like to compile Hermes, continue reading.
 
 ### Develop against ApolloGenome


### PR DESCRIPTION
## Summary

- add an `apollogene` Homebrew cask for the v200b6 universal release
- verify the release archive with its SHA-256 checksum and install it as `ApolloGene.app`
- require macOS 11 and remove ApolloGene preferences and saved state when zapping
- document tap trust, installation, upgrade, and uninstall commands

## Validation

- `brew style Casks/apollogene.rb`
- `brew audit --cask dtseto/hermes-master/apollogene`
- `brew info --cask dtseto/hermes-master/apollogene`
- verified the release checksum and application bundle layout
- confirmed the executable contains both x86_64 and arm64 slices
- `git diff --check`

## Release-signing note

The v200b6 archive contains a stapled notarization ticket, but its current code signature does not validate. The README therefore describes the release as universal without claiming that it is notarized.